### PR TITLE
開催日が近いもの順にソート完了 #2

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -8,6 +8,19 @@ function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
+
+// 配列を時間順に並び替える
+// array_column()の引数に、対象のキー名を指定し、開催日が近いもの順（過去→未来）でソート
+array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), SORT_ASC, $events ) ;
+
+//以下で確認
+// foreach($events as $event){
+//   echo "<pre>";
+//   echo $event["name"];
+//   echo $event["start_at"];
+//   echo "</pre>";
+//  }
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
## 関連イシュー
- #2 

## 検証したこと
開催日が近いもの順（過去→未来）でソートされるようにし、print_rや実際のlistを見て確認しました。

## エビデンス
**＜以前のもの＞**
![image](https://user-images.githubusercontent.com/86781636/188781323-6bdca00a-1494-403b-9523-d96a5037c898.png)
9/3, 6, 22が順番通りになっていません。

**＜実装後＞**
![image](https://user-images.githubusercontent.com/86781636/188781431-e8ae9135-8b59-497b-aa29-6bc2e2d4e0a2.png)
9月の分を含め、全て近いもの順になっています。
念のため、リストの証跡も以下の通りに残します。
![image](https://user-images.githubusercontent.com/86781636/188781548-c68a2fb7-0663-4e21-abd0-b9336451cbd6.png)
![image](https://user-images.githubusercontent.com/86781636/188781557-3fdafdb8-10db-44d4-acc3-44abc3d4ce71.png)
![image](https://user-images.githubusercontent.com/86781636/188781563-5d334281-f049-4e9f-b549-734e7cbbd64c.png)
