### PR TITLE
開催日が過去のイベントを表示しない #1

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -60,6 +60,7 @@ INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
 INSERT INTO events SET name='遊び', start_at='2023/10/06 18:00', end_at='2023/10/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/07 09:00', end_at='2022/09/07 22:00';
 
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/src/index.php
+++ b/src/index.php
@@ -2,7 +2,7 @@
 require('dbconnect.php');
 
 $today = date("Y-m-d H:i:s");
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d") >= DATE_FORMAT(now(), "%Y-%m-%d") GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
 $events = $stmt->fetchAll();
 
 

--- a/src/index.php
+++ b/src/index.php
@@ -1,13 +1,18 @@
 <?php
 require('dbconnect.php');
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$today = date("Y-m-d H:i:s");
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d") => DATE_FORMAT(now(), "%Y-%m-%d") GROUP BY events.id');
 $events = $stmt->fetchAll();
+
+
 
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
+print_r($events);
 ?>
 
 <!DOCTYPE html>

--- a/src/index.php
+++ b/src/index.php
@@ -1,18 +1,13 @@
 <?php
 require('dbconnect.php');
 
-$today = date("Y-m-d H:i:s");
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
 $events = $stmt->fetchAll();
-
-
 
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
-
-print_r($events);
 
 // 配列を時間順に並び替える
 // array_column()の引数に、対象のキー名を指定し、開催日が近いもの順（過去→未来）でソート


### PR DESCRIPTION
## 関連イシュー
- #1 

## 検証したこと
ダミーデータとして開催日が来年のイベントと今日(2022/09/07)のAM9:00のイベントを追加し、前者は表示されるが後者は表示されないか確認しました。

## エビデンス
![スクリーンショット (408)](https://user-images.githubusercontent.com/86661820/188785999-4b8356ce-b709-4682-969e-71183460a624.png)
![0907](https://user-images.githubusercontent.com/86661820/188785656-2f7a8564-29da-4071-a02f-50a655a870ba.png)
