### PR TITLE
管理者が対応しなくてもパスワード再設定が出来るようにする #9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,7 @@ services:
       - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
   mailhog:
     image: mailhog/mailhog
+    volumes:
+          - ./mailhog:/tmp
     ports:
       - "8025:8025"

--- a/src/auth/login/forgetpass.php
+++ b/src/auth/login/forgetpass.php
@@ -1,0 +1,88 @@
+<?php
+session_start();
+require('../../dbconnect.php');
+
+$errormessage = array();
+
+if (!empty($_POST)) {
+  $login = $db->prepare('SELECT * FROM admin WHERE mail_address = :mail_address');
+  $login->bindValue('mail_address', $_POST['mail_address']);
+  $login->execute();
+  $administrator = $login->fetch();
+
+  if (!empty($administrator)) {
+    $_SESSION = array();
+    $_SESSION['admin_name'] = $administrator['admin_name'];
+
+    header('Location: http://' . $_SERVER['HTTP_HOST'] . '/login/forget_pass_phone.php');
+  } else {
+    $errormessage[] = "入力されたメールアドレスは登録されていません";
+  }
+}
+
+//NULL 合体演算子を使ってセッション変数を初期化
+$email = $_SESSION['email'] ?? NULL;
+$error = $_SESSION['error'] ?? NULL;
+
+//個々のエラーを NULL で初期化
+$error_email = $error['email'] ?? NULL;
+
+//CSRF対策のトークンを生成
+if (!isset($_SESSION['ticket'])) {
+  //セッション変数にトークンを代入
+  $_SESSION['ticket'] = bin2hex(random_bytes(32));
+}
+//トークンを変数に代入（隠しフィールドに挿入する値）
+$ticket = $_SESSION['ticket'];
+
+
+
+?>
+
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>パスワードお忘れページ | POSSE</title>
+</head>
+
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+    </div>
+  </header>
+
+  <main class="bg-gray-100 h-screen">
+    <div class="w-full mx-auto py-10 px-5">
+      <h1 class="text-md font-bold mb-5">パスワードお忘れの方</h1>
+      <?php if ($errormessage) { ?>
+        <ul class='login_error'>
+          <!-- $errorは連想配列なのでforeachで分解していく -->
+          <?php foreach ($errormessage as $value) { ?>
+            <li><?php echo $value; ?></li>
+          <?php } ?>
+          <!-- 分解したエラー文をlistの中に表示していく -->
+        </ul>
+      <?php } ?>
+
+      <form action="./resetmail.php" method="POST">
+        <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3" name="email">
+        <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+        <!--確認ページへトークンをPOSTする、隠しフィールド「ticket」-->
+        <input type="hidden" name="ticket" value="<?php echo $ticket; ?>">
+      </form>
+
+    </div>
+  </main>
+</body>
+
+</html>

--- a/src/auth/login/forgetpass.php
+++ b/src/auth/login/forgetpass.php
@@ -76,7 +76,7 @@ $ticket = $_SESSION['ticket'];
 
       <form action="./resetmail.php" method="POST">
         <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3" name="email">
-        <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+        <input type="submit" value="送信" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
         <!--確認ページへトークンをPOSTする、隠しフィールド「ticket」-->
         <input type="hidden" name="ticket" value="<?php echo $ticket; ?>">
       </form>

--- a/src/auth/login/function.php
+++ b/src/auth/login/function.php
@@ -1,0 +1,31 @@
+<?php
+//エスケープ処理を行う関数
+function h($var) {
+  if(is_array($var)){
+    //$varが配列の場合、h()関数をそれぞれの要素について呼び出す（再帰）
+    return array_map('h', $var);
+  }else{
+    return htmlspecialchars($var, ENT_QUOTES, 'UTF-8');
+  }
+}
+ 
+//入力値に不正なデータがないかなどをチェックする関数
+function checkInput($var){
+  if(is_array($var)){
+    return array_map('checkInput', $var);
+  }else{
+    //NULLバイト攻撃対策
+    if(preg_match('/\0/', $var)){  
+      die('不正な入力です。');
+    }
+    //文字エンコードのチェック
+    if(!mb_check_encoding($var, 'UTF-8')){ 
+      die('不正な入力です。');
+    }
+    //改行、タブ以外の制御文字のチェック
+    if(preg_match('/\A[\r\n\t[:^cntrl:]]*\z/u', $var) === 0){  
+      die('不正な入力です。制御文字は使用できません。');
+    }
+    return $var;
+  }
+}

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -31,7 +31,7 @@
         <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
       <div class="text-center text-xs text-gray-400 mt-6">
-        <a href="/">パスワードを忘れた方はこちら</a>
+        <a href="./forgetpass.php">パスワードを忘れた方はこちら</a>
       </div>
     </div>
   </main>

--- a/src/auth/login/resetcomplete.php
+++ b/src/auth/login/resetcomplete.php
@@ -32,12 +32,7 @@ if ( isset( $_POST[ 'ticket' ], $_SESSION[ 'ticket' ] ) ) {
 $post = checkInput( $_POST );
 $email = $post['email'];
 $password = $post['password'];
-// print_r($post);
-// echo $post['email'];
-// echo $post['password'];
-
-// テーブルに保存するパスワードをハッシュ化
-$hashedPassword = password_hash($password, PASSWORD_BCRYPT);
+$password_confirmation = $post['password_confirmation'];
 
 // emailがusersテーブルに登録済みか確認
 $sql = 'SELECT * FROM users WHERE mail_address= ? ';
@@ -46,26 +41,36 @@ $stmt->bindValue(1,$email);
 $stmt->execute();
 $user = $stmt->fetch(\PDO::FETCH_OBJ);
 
-// print_r($user);
-
 // 未登録のメールアドレスはログイン画面に遷移
 if (!$user) {
     require_once './index.php';
     exit();
 }
 
-$query = "UPDATE users SET password='$hashedPassword' WHERE mail_address = ? '";
-$stmt = $db->prepare($sql);
-$stmt->bindValue(1,$email);
-$stmt->execute();
-$result = $stmt->fetchAll();
+if ($password === $password_confirmation) {
+  // テーブルに保存するパスワードをハッシュ化
+  $hashedPassword = password_hash($password, PASSWORD_BCRYPT);
 
-//以下で確認
-// if (isset($result)) {
-//   echo $return  = "パスワードを更新しました";
-// } else {
-//   echo $return  = "パスワードを更新できませんでした";
-// }
+  $query = "UPDATE users SET password='$hashedPassword' WHERE mail_address = ? '";
+  $stmt = $db->prepare($sql);
+  $stmt->bindValue(1,$email);
+  $stmt->execute();
+  $result = $stmt->fetchAll();
+  
+  //以下で確認
+  // if (isset($result)) {
+  //   echo $return  = "パスワードを更新しました";
+  // } else {
+  //   echo $return  = "パスワードを更新できませんでした";
+  // }
+
+}else {
+  echo "パスワードが一致しておりません。";
+  echo '<a href="./resetting.php">戻る</a>';
+  exit;
+}
+
+
 
 
 ?>

--- a/src/auth/login/resetcomplete.php
+++ b/src/auth/login/resetcomplete.php
@@ -1,0 +1,105 @@
+<?php
+//セッションを開始
+session_start(); 
+
+require('../../dbconnect.php');
+//エスケープ処理やデータをチェックする関数を記述したファイルの読み込み
+require './function.php'; 
+
+//固定トークンを確認（CSRF対策）
+if ( isset( $_POST[ 'ticket' ], $_SESSION[ 'ticket' ] ) ) {
+  $ticket = $_POST[ 'ticket' ];
+  if ( $ticket !== $_SESSION[ 'ticket' ] ) {
+    //トークンが一致しない場合は処理を中止
+    die( 'Access denied' );
+  }
+} else {
+  //トークンが存在しない場合（入力ページにリダイレクト）
+  //die( 'Access Denied（直接このページにはアクセスできません）' ); //処理を中止する場合
+  $dirname = dirname( $_SERVER[ 'SCRIPT_NAME' ] );
+  $dirname = $dirname === DIRECTORY_SEPARATOR ? '' : $dirname;
+  //サーバー変数 $_SERVER['HTTPS'] が取得出来ない環境用（オプション）
+  if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO'] === "https") {
+    $_SERVER[ 'HTTPS' ] = 'on';
+  }
+  $url = ( empty( $_SERVER[ 'HTTPS' ] ) ? 'http://' : 'https://' ) . $_SERVER[ 'SERVER_NAME' ] . $dirname . '/contact.php';
+  header( 'HTTP/1.1 303 See Other' );
+  header( 'location: ' . $url );
+  exit; //忘れないように
+}
+ 
+//POSTされたデータをチェック
+$post = checkInput( $_POST );
+$email = $post['email'];
+$password = $post['password'];
+// print_r($post);
+// echo $post['email'];
+// echo $post['password'];
+
+// テーブルに保存するパスワードをハッシュ化
+$hashedPassword = password_hash($password, PASSWORD_BCRYPT);
+
+// emailがusersテーブルに登録済みか確認
+$sql = 'SELECT * FROM users WHERE mail_address= ? ';
+$stmt = $db->prepare($sql);
+$stmt->bindValue(1,$email);
+$stmt->execute();
+$user = $stmt->fetch(\PDO::FETCH_OBJ);
+
+// print_r($user);
+
+// 未登録のメールアドレスはログイン画面に遷移
+if (!$user) {
+    require_once './index.php';
+    exit();
+}
+
+$query = "UPDATE users SET password='$hashedPassword' WHERE mail_address = ? '";
+$stmt = $db->prepare($sql);
+$stmt->bindValue(1,$email);
+$stmt->execute();
+$result = $stmt->fetchAll();
+
+//以下で確認
+// if (isset($result)) {
+//   echo $return  = "パスワードを更新しました";
+// } else {
+//   echo $return  = "パスワードを更新できませんでした";
+// }
+
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>パスワードリセット完了 | POSSE</title>
+</head>
+
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+    </div>
+  </header>
+
+  <main class="bg-gray-100 h-screen">
+    <div class="w-full mx-auto py-10 px-5">
+      <h1 class="text-md font-bold mb-5">リセット完了</h1>
+
+      <p class="w-full p-4 text-sm mb-3 bg-white">パスワードリセット再設定が完了しました。</p>
+      <a href="./index.php" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" >ログイン</a>
+
+    </div>
+  </main>
+</body>
+
+</html>

--- a/src/auth/login/resetmail.php
+++ b/src/auth/login/resetmail.php
@@ -6,13 +6,13 @@ require('../../dbconnect.php');
 //エスケープ処理やデータをチェックする関数を記述したファイルの読み込み
 require './function.php'; 
 
+
 //お問い合わせ日時を日本時間に
 date_default_timezone_set('Asia/Tokyo'); 
 
 //POSTされたデータをチェック
 $_POST = checkInput( $_POST );
 
-print_r($_POST);
 
 //固定トークンを確認（CSRF対策）
 if ( isset( $_POST[ 'ticket' ], $_SESSION[ 'ticket' ] ) ) {
@@ -38,7 +38,21 @@ if ( isset( $_POST[ 'ticket' ], $_SESSION[ 'ticket' ] ) ) {
  
 //セッション変数の値を代入
 $email = $_POST[ 'email' ];
-print_r($email);
+
+// emailがusersテーブルに登録済みか確認
+$sql = 'SELECT * FROM users WHERE mail_address= ? ';
+$stmt = $db->prepare($sql);
+$stmt->bindValue(1,$email);
+$stmt->execute();
+$user = $stmt->fetch(\PDO::FETCH_OBJ);
+
+
+// 未登録のメールアドレスはログイン画面に遷移
+if (!$user) {
+    require_once './index.php';
+    exit();
+}
+
 
 /* メールの作成 */
 
@@ -109,7 +123,7 @@ $mailsousin  = mb_send_mail($mail_to, $mail_subject, $mail_body, $mail_header);
     <div class="w-full mx-auto py-10 px-5">
       <h1 class="text-md font-bold mb-5">リセットメール送信完了</h1>
 
-      <p class="w-full p-4 text-sm mb-3">パスワードリセットに必要なメールを送信しました。メール記載のリンクをクリックし、パスワードの再設定をしてください。</p>
+      <p class="w-full p-4 text-sm mb-3 bg-white">パスワードリセットに必要なメールを送信しました。メール記載のリンクをクリックし、パスワードの再設定をしてください。</p>
 
     </div>
   </main>

--- a/src/auth/login/resetmail.php
+++ b/src/auth/login/resetmail.php
@@ -1,0 +1,118 @@
+<?php
+//セッションを開始
+session_start(); 
+
+require('../../dbconnect.php');
+//エスケープ処理やデータをチェックする関数を記述したファイルの読み込み
+require './function.php'; 
+
+//お問い合わせ日時を日本時間に
+date_default_timezone_set('Asia/Tokyo'); 
+
+//POSTされたデータをチェック
+$_POST = checkInput( $_POST );
+
+print_r($_POST);
+
+//固定トークンを確認（CSRF対策）
+if ( isset( $_POST[ 'ticket' ], $_SESSION[ 'ticket' ] ) ) {
+  $ticket = $_POST[ 'ticket' ];
+  if ( $ticket !== $_SESSION[ 'ticket' ] ) {
+    //トークンが一致しない場合は処理を中止
+    die( 'Access denied' );
+  }
+} else {
+  //トークンが存在しない場合（入力ページにリダイレクト）
+  //die( 'Access Denied（直接このページにはアクセスできません）' ); //処理を中止する場合
+  $dirname = dirname( $_SERVER[ 'SCRIPT_NAME' ] );
+  $dirname = $dirname === DIRECTORY_SEPARATOR ? '' : $dirname;
+  //サーバー変数 $_SERVER['HTTPS'] が取得出来ない環境用（オプション）
+  if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO'] === "https") {
+    $_SERVER[ 'HTTPS' ] = 'on';
+  }
+  $url = ( empty( $_SERVER[ 'HTTPS' ] ) ? 'http://' : 'https://' ) . $_SERVER[ 'SERVER_NAME' ] . $dirname . '/contact.php';
+  header( 'HTTP/1.1 303 See Other' );
+  header( 'location: ' . $url );
+  exit; //忘れないように
+}
+ 
+//セッション変数の値を代入
+$email = $_POST[ 'email' ];
+print_r($email);
+
+/* メールの作成 */
+
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+//メール本文の組み立て
+$honbun = '';
+$honbun .= "メールフォームよりお問い合わせがありました。\n\n";
+$honbun .= "【メールアドレス】\n";
+$honbun .= $email . "\n\n";
+$honbun .= "【お問い合わせ内容】\n";
+$honbun .= "下記のURLよりPOSSEアプリのログインパスワードを変更してください。" . "\n";
+$honbun .= "http://localhost/auth/login/resetting.php" . "\n\n";
+
+  
+//-------- sendmail（mb_send_mail）を使ったメールの送信処理------------
+/* 
+ mail_to($宛先):	送信先のメールアドレス 
+ returnMail:  Return-Pathに指定するメールアドレス
+ mail_subject($件名):	メールの件名
+ mail_body($本文):  メールの本文
+ mail_header($ヘッダー):	ヘッダー
+    from:  送信元として表示されるメールアドレス
+    Return-Path:  fromと同じメアド
+    以下headerの文字化け防止
+      ・MIME-Version
+      ・Content-Transfer-Encoding
+      ・Content-Type
+*/
+$mail_to  = $email;
+$returnMail  = $email;
+$mail_subject  = "パスポート再設定 | POSSE";
+$mail_body  = $honbun . "\n\n";
+$mail_header = "from: ayaka1712pome@gmail.com\r\n"
+             . "Return-Path: ayaka1712pome@gmail.com\r\n"
+             . "MIME-Version: 1.0\r\n"
+             . "Content-Transfer-Encoding: BASE64\r\n"
+             . "Content-Type: text/plain; charset=UTF-8\r\n";
+
+//メール送信処理
+$mailsousin  = mb_send_mail($mail_to, $mail_subject, $mail_body, $mail_header);
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>パスワードリセットメール送信 | POSSE</title>
+</head>
+
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+    </div>
+  </header>
+
+  <main class="bg-gray-100 h-screen">
+    <div class="w-full mx-auto py-10 px-5">
+      <h1 class="text-md font-bold mb-5">リセットメール送信完了</h1>
+
+      <p class="w-full p-4 text-sm mb-3">パスワードリセットに必要なメールを送信しました。メール記載のリンクをクリックし、パスワードの再設定をしてください。</p>
+
+    </div>
+  </main>
+</body>
+
+</html>

--- a/src/auth/login/resetting.php
+++ b/src/auth/login/resetting.php
@@ -1,0 +1,89 @@
+<?php
+session_start();
+require('../../dbconnect.php');
+
+$errormessage = array();
+
+if (!empty($_POST)) {
+  $login = $db->prepare('SELECT * FROM admin WHERE mail_address = :mail_address');
+  $login->bindValue('mail_address', $_POST['mail_address']);
+  $login->execute();
+  $administrator = $login->fetch();
+
+  if (!empty($administrator)) {
+    $_SESSION = array();
+    $_SESSION['admin_name'] = $administrator['admin_name'];
+
+    header('Location: http://' . $_SERVER['HTTP_HOST'] . '/login/forget_pass_phone.php');
+  } else {
+    $errormessage[] = "入力されたメールアドレスは登録されていません";
+  }
+}
+
+//NULL 合体演算子を使ってセッション変数を初期化
+$email = $_SESSION['email'] ?? NULL;
+$error = $_SESSION['error'] ?? NULL;
+
+//個々のエラーを NULL で初期化
+$error_email = $error['email'] ?? NULL;
+
+//CSRF対策のトークンを生成
+if (!isset($_SESSION['ticket'])) {
+  //セッション変数にトークンを代入
+  $_SESSION['ticket'] = bin2hex(random_bytes(32));
+}
+//トークンを変数に代入（隠しフィールドに挿入する値）
+$ticket = $_SESSION['ticket'];
+
+
+
+?>
+
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>パスワード再設定ページ | POSSE</title>
+</head>
+
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+    </div>
+  </header>
+
+  <main class="bg-gray-100 h-screen">
+    <div class="w-full mx-auto py-10 px-5">
+      <h1 class="text-md font-bold mb-5">パスワード再設定</h1>
+      <?php if ($errormessage) { ?>
+        <ul class='login_error'>
+          <!-- $errorは連想配列なのでforeachで分解していく -->
+          <?php foreach ($errormessage as $value) { ?>
+            <li><?php echo $value; ?></li>
+          <?php } ?>
+          <!-- 分解したエラー文をlistの中に表示していく -->
+        </ul>
+      <?php } ?>
+
+      <form action="./resetmail.php" method="POST">
+      <input type="password" placeholder="新しいパスワード" class="w-full p-4 text-sm mb-3">
+      <input type="password" placeholder="新しいパスワード(再確認)" class="w-full p-4 text-sm mb-3">
+      <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+        <!--確認ページへトークンをPOSTする、隠しフィールド「ticket」-->
+        <input type="hidden" name="ticket" value="<?php echo $ticket; ?>">
+      </form>
+
+    </div>
+  </main>
+</body>
+
+</html>

--- a/src/auth/login/resetting.php
+++ b/src/auth/login/resetting.php
@@ -74,10 +74,11 @@ $ticket = $_SESSION['ticket'];
         </ul>
       <?php } ?>
 
-      <form action="./resetmail.php" method="POST">
-      <input type="password" placeholder="新しいパスワード" class="w-full p-4 text-sm mb-3">
-      <input type="password" placeholder="新しいパスワード(再確認)" class="w-full p-4 text-sm mb-3">
-      <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+      <form action="./resetcomplete.php" method="POST">
+      <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3" name="email">
+      <input type="password" placeholder="新しいパスワード" class="w-full p-4 text-sm mb-3" name="password">
+      <input type="password" placeholder="新しいパスワード(再確認)" class="w-full p-4 text-sm mb-3" name="password_confirmation">
+      <input type="submit" value="変更" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
         <!--確認ページへトークンをPOSTする、隠しフィールド「ticket」-->
         <input type="hidden" name="ticket" value="<?php echo $ticket; ?>">
       </form>


### PR DESCRIPTION
## 関連イシュー
- #9 

## 検証したこと
index.php(ログイン)の忘れた方へのリンク先に下記ページ(forgetpass.php)を追記。
forgetpass.php に遷移後、メールアドレスを入力。
入力したメールアドレスがユーザーであれば、パスワード変更メールを送信(mailhogで確認)
メールに送付されたURLからリセットページ(resetting.php)へ遷移。
resetting.php に遷移後、メールアドレス、パスワード、確認パスワードを入力。
パスワードと確認パスワードが一致した時に登録可能となり、resetcomplete.phpに遷移する。
resetcomplete.phpに遷移後、パスワードが変更されたこと、そしてログインボタンが設置され、index.php(ログイン)に遷移できるようになっている。


## エビデンス
![image](https://user-images.githubusercontent.com/86781636/188858383-84e330b5-081c-4b68-85f7-98f145eae99b.png)
![image](https://user-images.githubusercontent.com/86781636/188858414-4593eab1-ff43-4098-bc00-ee208df16c12.png)
![image](https://user-images.githubusercontent.com/86781636/188858441-de657695-2666-4e2e-827e-fb92c549ab3a.png)
![image](https://user-images.githubusercontent.com/86781636/188858477-3a31d356-54e5-4471-b430-cea8b9f0a026.png)
![image](https://user-images.githubusercontent.com/86781636/188858546-dac33408-aa27-425a-94c6-bddf79087cbd.png)
![image](https://user-images.githubusercontent.com/86781636/188858571-0e178a37-c45f-4534-b1d2-e521feca32ba.png)
⇩パスワードが一致していない場合
![image](https://user-images.githubusercontent.com/86781636/188858632-aba4a35a-6aaf-41f7-a527-105519cd28a5.png)
⇩コメントアウトを消してpush
![image](https://user-images.githubusercontent.com/86781636/188858859-9bcab576-d43b-40e3-b019-ed094f5f7403.png)

