### PR TITLE
イベント参加管理 Issue1 誰が参加するかDBに保存する #12

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -1,5 +1,6 @@
 <?php
 require('dbconnect.php');
+session_start();
 
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
 $events = $stmt->fetchAll();
@@ -20,6 +21,12 @@ array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), 
 //   echo $event["start_at"];
 //   echo "</pre>";
 //  }
+
+$user_id = $_SESSION['user_id'];
+if(isset($_POST['user_name'])) {
+  
+}
+
 ?>
 
 <!DOCTYPE html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -51,7 +51,7 @@ async function openModal(eventId) {
             -->
           </div>
           <div class="flex mt-5">
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+            <button type="submit" name="join_button" class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
             <!-- 
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
             -->
@@ -93,6 +93,8 @@ function toggleModal() {
 
 async function participateEvent(eventId) {
   try {
+    // FormData() サーバーにデータを送信する際に使用するオブジェクト。ユーザーが入力するフォームデータや任意のデータをサーバーに送信できる
+    // append() 要素を追加
     let formData = new FormData();
     formData.append('eventId', eventId)
     const url = '/api/postEventAttendance.php'


### PR DESCRIPTION
## 関連イシュー
- #12 

## 検証したこと
ユーザーがイベントの「参加する」ボタンを押すと、ユーザーとイベントのidがevent_attendanceテーブルに追加されることを確認しました。
ターミナルでsql文を入力して、イベント参加者が表示されることを確認しました。

## エビデンス
![スクリーンショット (426)](https://user-images.githubusercontent.com/86661820/188934333-26778e02-1f14-4dc9-880b-2798f87a9304.png)
![スクリーンショット (425)](https://user-images.githubusercontent.com/86661820/188934383-6cb02e06-4277-4fa8-8e6b-a1c8539ffb23.png)
