### PR TITLE
パスワードを平文で保存せず、ハッシュ化する #8

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -93,6 +93,6 @@ VALUES
 INSERT INTO users
   (user_name, mail_address, password)
   VALUES
-  ('あやか', 'pome@gmail.com', 'ayaka'),
-  ('みのり', 'minori@gmail.com', 'minori'),
-  ('まりあ', 'maria@gmail.com', 'maria');
+  ('あやか', 'pome@gmail.com', sha1('ayaka')),
+  ('みのり', 'minori@gmail.com', sha1('minori')),
+  ('まりあ', 'maria@gmail.com', sha1('maria'));

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -21,7 +21,7 @@ if (isset(
   // これらが入力されていたら
   $_POST['user_name'],
   $_POST['email'],
-  $_POST['password']
+  sha1($_POST['password'])
 )) {
    // ユーザ情報をDBに登録
     $stmt = $db->prepare(
@@ -40,7 +40,7 @@ if (isset(
   );
   $user_name = $_POST['user_name'];
   $email = $_POST['email'];
-  $password = $_POST['password'];
+  $password = sha1($_POST['password']);
   $param = array(
     ':user_name' => $user_name,
     ':email' => $email,

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -9,7 +9,7 @@ if (!empty($_POST)) {
   // usersからデータを取ってくる
   $user_login->execute(array(
     $_POST['email'],
-    $_POST['password']
+    sha1($_POST['password'])
   ));
   // ポストされたものと一致するデータがあれば取得を実行
   $user = $user_login->fetch();
@@ -19,7 +19,7 @@ if (!empty($_POST)) {
   $admin_login = $db->prepare('SELECT * FROM admin WHERE mail_address = ? AND password = ?');
   $admin_login->execute(array(
     $_POST['email'],
-    $_POST['password']
+    sha1($_POST['password'])
   ));
    // ポストされたものと一致するデータがあれば取得を実行
   $admin = $admin_login->fetch();

--- a/src/auth/login/resetcomplete.php
+++ b/src/auth/login/resetcomplete.php
@@ -49,7 +49,7 @@ if (!$user) {
 
 if ($password === $password_confirmation) {
   // テーブルに保存するパスワードをハッシュ化
-  $hashedPassword = password_hash($password, PASSWORD_BCRYPT);
+  $hashedPassword = sha1($password);
 
   $query = "UPDATE users SET password='$hashedPassword' WHERE mail_address = ? '";
   $stmt = $db->prepare($sql);


### PR DESCRIPTION
## 関連イシュー
- #8 

## 検証したこと
init.sqlにパスワードの記述をハッシュ関数を用いたものに変更し、ターミナルに入ってハッシュ化されていることを確認した。
ハッシュ化したパスワードを用いてもログインができることを確認し、その他パスワードを再設定するための記述も同様にハッシュ化を用いたものに変更した。

## エビデンス
![image](https://user-images.githubusercontent.com/86781636/188945754-d7971b6d-d9f4-4c40-b8dc-7dcf937e2c93.png)

