### PR TITLE
イベントの前日にメールでユーザー全員に通知するように実装 #18

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS events;
 CREATE TABLE events (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   name VARCHAR(10) NOT NULL,
+  contents VARCHAR(50) NOT NULL,
   start_at DATETIME,
   end_at DATETIME,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -44,30 +45,30 @@ CREATE TABLE admin (
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/10/06 18:00', end_at='2021/10/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/07 09:00', end_at='2022/09/07 22:00';
-INSERT INTO events SET name='縦モク', start_at='2022/10/07 09:00', end_at='2022/10/07 22:00';
-INSERT INTO events SET name='縦モク', start_at='2022/10/08 09:00', end_at='2022/10/08 22:00';
-INSERT INTO events SET name='縦モク', start_at='2022/10/10 09:00', end_at='2022/10/10 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/10/06 09:00', end_at='2022/10/06 22:00';
-INSERT INTO events SET name='スぺモク', start_at='2022/10/09 09:00', end_at='2022/10/09 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2022/10/20 09:00', end_at='2022/10/20 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/10/10 09:00', end_at='2022/10/10 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
+INSERT INTO events SET name='横モク', contents='同期ともくもくします。', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
+INSERT INTO events SET name='スペモク', contents='メンターさんともくもくします。', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
+INSERT INTO events SET name='横モク', contents='同期ともくもくします。', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
+INSERT INTO events SET name='スペモク', contents='メンターさんともくもくします。', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
+INSERT INTO events SET name='横モク', contents='同期ともくもくします。', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
+INSERT INTO events SET name='スペモク', contents='メンターさんともくもくします。', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
+INSERT INTO events SET name='横モク', contents='同期ともくもくします。', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
+INSERT INTO events SET name='スペモク', contents='メンターさんともくもくします。', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
+INSERT INTO events SET name='遊び', contents='リアイベ！遊びます。', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
+INSERT INTO events SET name='ハッカソン', contents='お題に沿ったものをチーム開発します。', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
+INSERT INTO events SET name='遊び', contents='リアイベ！遊びます。', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', contents='リアイベ！遊びます。', start_at='2021/10/06 18:00', end_at='2021/10/06 22:00';
+INSERT INTO events SET name='遊び', contents='リアイベ！遊びます。', start_at='2022/09/09 09:00', end_at='2022/09/09 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2022/09/10 09:00', end_at='2022/09/10 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2022/09/10 09:00', end_at='2022/09/10 22:00';
+INSERT INTO events SET name='縦モク', contents='先輩ともくもくします。', start_at='2022/10/10 09:00', end_at='2022/10/10 22:00';
+INSERT INTO events SET name='横モク', contents='同期ともくもくします。', start_at='2022/10/06 09:00', end_at='2022/10/06 22:00';
+INSERT INTO events SET name='スぺモク', contents='もくもくします。', start_at='2022/10/09 09:00', end_at='2022/10/09 22:00';
+INSERT INTO events SET name='ハッカソン', contents='お題に沿ったものをチーム開発します。', start_at='2022/10/20 09:00', end_at='2022/10/20 22:00';
+INSERT INTO events SET name='遊び', contents='リアイベ！遊びます。', start_at='2022/10/10 09:00', end_at='2022/10/10 22:00';
 
 INSERT INTO event_attendance SET event_id=1, user_id=1;
 INSERT INTO event_attendance SET event_id=1, user_id=2;

--- a/src/noticeforall.php
+++ b/src/noticeforall.php
@@ -1,0 +1,55 @@
+<?php
+require('./dbconnect.php');
+
+/* メールの作成 （to ユーザレコードの人全て）*/
+$sql = 'SELECT 
+          events.name AS e_name, events.contents AS contents ,DATE_FORMAT(start_at, "%Y/%m/%d") AS date, users.user_name 
+          from events 
+          left join event_attendance 
+          on events.id = event_attendance.event_id 
+          left join users on event_attendance.user_id = users.id 
+          -- WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") 
+          order by events.name DESC; ';
+$stmt = $db->query($sql);
+$events_table = $stmt->fetchAll();
+
+// ユーザレコード取得
+$sql = "SELECT * from users;";
+$stmt = $db->query($sql);
+$users = $stmt->fetchAll();
+
+//もし処理日がイベントの前日の場合、メールを送付する
+for ($i = 0; $i < count($events_table); $i++) {
+  $tomorrow = date("Y/m/d", strtotime("+1 day"));
+  // echo  $tomorrow;
+  echo $events_table[$i]["date"];
+  echo $tomorrow;
+  if ($events_table[$i]["date"] === $tomorrow) {
+    // ユーザレコードの人数だけループ
+    foreach ($users as $user) {
+      //メール本文の用意
+      $honbun = '';
+      $honbun .= "【イベント名】\n";
+      $honbun .= $events_table[$i]["e_name"] . "\n\n";
+      $honbun .= "【内容】\n";
+      $honbun .= $events_table[$i]["contents"] . "\n\n";
+      $honbun .= "【開催日時】\n";
+      $honbun .= $events_table[$i]["date"] . "\n\n";
+      //-------- sendmail（mb_send_mail）を使ったメールの送信処理------------
+      $mail_to  = $user['mail_address'];
+      $returnMail  = $user['mail_address'];
+      $mail_subject  = "POSSE | イベント情報 前日リマインド";
+      $mail_body  = $honbun . "\n\n";
+      $mail_header = "from: ayaka1712pome@gmail.com\r\n"
+        . "Return-Path: ayaka1712pome@gmail.com\r\n"
+        . "MIME-Version: 1.0\r\n"
+        . "Content-Transfer-Encoding: BASE64\r\n"
+        . "Content-Type: text/plain; charset=UTF-8\r\n";
+      //メール送信処理
+      $mailsousin  = mb_send_mail($mail_to, $mail_subject, $mail_body, $mail_header);
+    }
+    echo "メール送信";
+  } else {
+    echo "前日のイベントはありません。";
+  }
+}


### PR DESCRIPTION
## 関連イシュー
- #18 

## 検証したこと
バッチを実行すると処理日がイベントの前日の場合、ユーザレコードの人全てメールを送付するように、echo の内容とmailhogで確認した。
メールにはイベント名、内容、開催日時を記載していることも確認した。

## エビデンス
![image](https://user-images.githubusercontent.com/86781636/188980284-acf00ec5-c3a0-4b88-b3d2-7a4e9bdc973c.png)
↑ターミナルの状況。[php-fpm](php:7.4-fpm)コンテナにて、
`php  noticeforall.php`を実行したところ、上記のようになった。
![image](https://user-images.githubusercontent.com/86781636/188980982-fcdefb66-a1dd-458f-82be-de6cd9e96e6a.png)
↑usersテーブル。この時3人いることがわかる。
![image](https://user-images.githubusercontent.com/86781636/188980834-ce186d43-ab58-4518-95a0-cac4216f6ceb.png)
![image](https://user-images.githubusercontent.com/86781636/188981137-9e3e05a5-fbfe-4d23-9a5e-159b3e52eb53.png)
![image](https://user-images.githubusercontent.com/86781636/188981174-01e9727a-8a95-4a2a-8072-7a1477fcaa26.png)
![image](https://user-images.githubusercontent.com/86781636/188981190-1e0cadec-bc53-4eba-8991-beb0c34e1dbf.png)
↑全員に対して通知メールが送信されたことを確認した。

