### PR TITLE
イベント一覧 Issue3 自分が参加するイベントでフィルタ可能 #3

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -11,8 +11,7 @@ if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
   exit();
 }
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
-$events = $stmt->fetchAll();
+
 $stmt = $db->prepare('SELECT count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") and events.id = ? AND attendance = true GROUP BY events.id');
 $stmt = $db->query('SELECT count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") and attendance = true GROUP BY events.id');
 $stmt->execute();
@@ -22,6 +21,46 @@ function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
+
+
+
+
+
+
+// if(isset($_POST['all'])) {
+  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
+  $events = $stmt->fetchAll();
+// }
+// elseif(isset($_POST['join'])) {
+//   $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
+
+// }
+
+
+
+// 自分が参加するイベントでフィルタ
+// セッションで自分のuser_idを取得→
+// フィルター  https://qiita.com/westhouse_k/items/56cc472edfe3d53ded49
+// print_r($join_events);
+// $res = array_filter($events, function($val) {
+//   return $val === $user_id;
+// });
+// print_r($res);
+
+if(isset($_POST['all'])) {
+  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") GROUP BY events.id');
+  $events = $stmt->fetchAll();
+} elseif(isset($_POST['join'])) {
+  $user_id = $_SESSION['user_id'];
+  $stmt = $db->prepare('select events.name, events.start_at, users.user_name from events left join event_attendance on events.id = event_attendance.event_id left join users on event_attendance.user_id = users.id where DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") AND users.id = ? order by events.name DESC');
+  $stmt->execute(array(
+    $user_id
+  ));
+  $events = $stmt->fetchAll();
+}
+
+
 
 // 配列を時間順に並び替える
 // array_column()の引数に、対象のキー名を指定し、開催日が近いもの順（過去→未来）でソート
@@ -34,24 +73,6 @@ array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), 
 //   echo $event["start_at"];
 //   echo "</pre>";
 //  }
-
-
-
-// $user_id = $_SESSION['user_id'];
-// $stmt = $db->prepare('select events.name, DATE_FORMAT(start_at, "%Y/%m/%d"), users.user_name from events left join event_attendance on events.id = event_attendance.event_id left join users on event_attendance.user_id = users.id where DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") AND users.id = ? order by events.name DESC');
-// $stmt->execute(array(
-//   $user_id
-// ));
-
-// $join_events = $stmt->fetchAll();
-
-// 自分が参加するイベントでフィルタ
-// セッションで自分のuser_idを取得→
-// フィルター
-$res = array_filter($events, function($val) {
-    return $val === $user_id;
-});
-
 
 ?>
 
@@ -85,12 +106,12 @@ $res = array_filter($events, function($val) {
       
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
-        <div class="flex">
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">全て</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
-        </div>
+        <form action ="" method="POST" class="flex">
+          <input type="submit" name="all" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white" value="全て">
+          <input type="submit" name="join"  class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white" value="参加">
+          <input type="submit" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white" value="不参加">
+          <input type="submit" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white" value="未回答">
+        </form>
       </div>
   
       <div id="events-list">

--- a/src/index.php
+++ b/src/index.php
@@ -18,7 +18,6 @@ $stmt = $db->query('SELECT count(event_attendance.id) AS total_participants FROM
 $stmt->execute();
 $total_participants = $stmt->fetchAll();
 
-
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
@@ -38,6 +37,20 @@ array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), 
 
 
 
+// $user_id = $_SESSION['user_id'];
+// $stmt = $db->prepare('select events.name, DATE_FORMAT(start_at, "%Y/%m/%d"), users.user_name from events left join event_attendance on events.id = event_attendance.event_id left join users on event_attendance.user_id = users.id where DATE_FORMAT(start_at, "%Y-%m-%d %H:%i:%s") >= DATE_FORMAT(now(), "%Y-%m-%d %H:%i:%s") AND users.id = ? order by events.name DESC');
+// $stmt->execute(array(
+//   $user_id
+// ));
+
+// $join_events = $stmt->fetchAll();
+
+// 自分が参加するイベントでフィルタ
+// セッションで自分のuser_idを取得→
+// フィルター
+$res = array_filter($events, function($val) {
+    return $val === $user_id;
+});
 
 
 ?>
@@ -69,7 +82,7 @@ array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), 
 
   <main class="bg-gray-100">
     <div class="w-full mx-auto p-5">
-      <!-- 
+      
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
@@ -79,7 +92,7 @@ array_multisort( array_map( "strtotime", array_column( $events, "start_at" ) ), 
           <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
         </div>
       </div>
-      -->
+  
       <div id="events-list">
         <div class="flex justify-between items-center mb-3">
           <h2 class="text-sm font-bold">一覧</h2>


### PR DESCRIPTION
## 関連イシュー
- #3 

## 検証したこと
DBに登録されているユーザ情報でログインし、参加のボタンを押すと参加登録したイベントのみ表示されることを確認しました。
event_attendanceテーブルで、ログインしたユーザが参加としているイベントと表示されているイベントが同じか確認しました。

## エビデンス
全てをクリックした場合
![image](https://user-images.githubusercontent.com/86661820/189047100-d8f6d59a-1d3f-4951-8ad5-92b2d98498cc.png)

参加をクリックした場合
![image](https://user-images.githubusercontent.com/86661820/189047039-ecda6838-d3f2-497d-9e4f-1f0b2eeda675.png)

ログインしたユーザーが参加登録したイベント
![image](https://user-images.githubusercontent.com/86661820/189048336-e7528569-3971-4b98-8fde-8665458e659d.png)
