### PR TITLE
管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空 #21

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -89,7 +89,7 @@ INSERT INTO event_attendance
 INSERT INTO admin
   (admin_name, mail_address, password)
 VALUES 
-  ('小谷さん', 'kotani@gmail.com', 'kotani');
+  ('小谷さん', 'kotani@gmail.com', sha1('kotani'));
 
 INSERT INTO users
   (user_name, mail_address, password)

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -19,7 +19,7 @@ if (isset(
   // これらが入力されていたら
   $_POST['user_name'],
   $_POST['email'],
-  sha1($_POST['password'])
+  $_POST['password']
 )) {
    // ユーザ情報をDBに登録
     $stmt = $db->prepare(

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -57,6 +57,13 @@ if (isset(
   $_POST['finish_date'],
   $_POST['contents']
 )) {
+$start_date = $_POST['start_date'];
+$start_date = str_replace(array("T"), " ", $start_date); //Tを空白へ変更
+$start_date = $start_date.":00";
+$finish_date = $_POST['finish_date'];
+$finish_date = str_replace(array("T"), " ", $finish_date); //Tを空白へ変更
+$finish_date = $finish_date.":00";
+// echo $start_date;
    // ユーザ情報をDBに登録
     $stmt = $db->prepare(
     'insert into events
@@ -64,25 +71,27 @@ if (isset(
       name,
       contents,
       start_at,
-      end_at
+      end_at,
+      deleted_at
     )
     values
     (
       :event_name,
       :contents,
       :start_at,
-      :end_at
+      :end_at,
+      null
     )'
   );
   $event_name = $_POST['event_name'];
   $contents = $_POST['contents'];
-  $start_at = $_POST['start_date'];
-  $finish_at = $_POST['finish_date'];
+  $start_at = $start_date;
+  $finish_at = $finish_date;
   $param = array(
     ':user_name' => $user_name,
     ':contents' => $contents,
     ':start_at' => $start_at,
-    ':finish_at' => $finish_at
+    ':end_at' => $finish_at
   );
   
   $stmt->execute($param);
@@ -139,7 +148,7 @@ if (isset(
         <label for="finish_date">終了日時</label><br>
         <input type="datetime-local" name="finish_date" id="finishDate" class="w-full p-4 text-sm mb-3" required>
         <label for="contents">イベント内容</label><br>
-        <input type="contents" name="contents" id="contents" class="w-full p-4 text-sm mb-3" required>
+        <input type="text" name="contents" id="contents" class="w-full p-4 text-sm mb-3">
         <button type="submit" name="btn_confirm" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" style="display:hide">登録</button>
       </form>
 

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -14,7 +14,7 @@ if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
   exit();
 }
 
-
+// ユーザ登録
 if (isset(
   // これらが入力されていたら
   $_POST['user_name'],
@@ -47,6 +47,49 @@ if (isset(
   
   $stmt->execute($param);
 }
+
+
+// イベント登録
+if (isset(
+  // これらが入力されていたら
+  $_POST['event_name'],
+  $_POST['start_date'],
+  $_POST['finish_date'],
+  $_POST['contents']
+)) {
+   // ユーザ情報をDBに登録
+    $stmt = $db->prepare(
+    'insert into events
+    (
+      name,
+      contents,
+      start_at,
+      end_at
+    )
+    values
+    (
+      :event_name,
+      :contents,
+      :start_at,
+      :end_at
+    )'
+  );
+  $event_name = $_POST['event_name'];
+  $contents = $_POST['contents'];
+  $start_at = $_POST['start_date'];
+  $finish_at = $_POST['finish_date'];
+  $param = array(
+    ':user_name' => $user_name,
+    ':contents' => $contents,
+    ':start_at' => $start_at,
+    ':finish_at' => $finish_at
+  );
+  
+  $stmt->execute($param);
+}
+
+
+
 ?>
 
 <!DOCTYPE html>
@@ -84,6 +127,19 @@ if (isset(
         <input type="email" name="email" id="email" class="w-full p-4 text-sm mb-3" required>
         <label for="paspasswordword">パスワード</label><br>
         <input type="password" name="password" id="password" class="w-full p-4 text-sm mb-3" required>
+        <button type="submit" name="btn_confirm" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" style="display:hide">登録</button>
+      </form>
+      <!-- 管理画面からイベント登録出来る -->
+      <h1 class="text-md font-bold mb-5">イベント登録</h1>
+      <form action="index.php" method="POST" class="w-full p-4 text-sm mb-3">
+        <label for="eventName">イベント名</label><br>
+        <input type="text" name="event_name" id="eventName" class="w-full p-4 text-sm mb-3" required>
+        <label for="start_date">開始日時</label><br>
+        <input type="datetime-local" name="start_date" id="startDate" class="w-full p-4 text-sm mb-3" required>
+        <label for="finish_date">終了日時</label><br>
+        <input type="datetime-local" name="finish_date" id="finishDate" class="w-full p-4 text-sm mb-3" required>
+        <label for="contents">イベント内容</label><br>
+        <input type="contents" name="contents" id="contents" class="w-full p-4 text-sm mb-3" required>
         <button type="submit" name="btn_confirm" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" style="display:hide">登録</button>
       </form>
 

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -71,16 +71,14 @@ $finish_date = $finish_date.":00";
       name,
       contents,
       start_at,
-      end_at,
-      deleted_at
+      end_at
     )
     values
     (
       :event_name,
       :contents,
       :start_at,
-      :end_at,
-      null
+      :end_at
     )'
   );
   $event_name = $_POST['event_name'];
@@ -88,7 +86,7 @@ $finish_date = $finish_date.":00";
   $start_at = $start_date;
   $finish_at = $finish_date;
   $param = array(
-    ':user_name' => $user_name,
+    ':event_name' => $event_name,
     ':contents' => $contents,
     ':start_at' => $start_at,
     ':end_at' => $finish_at


### PR DESCRIPTION
## 関連イシュー
- #21 
## 検証したこと
DBに登録した管理者の情報を用いて管理画面にログインし、実際にイベント名・開催日時等を登録し、それらの情報がDBに追加されているかターミナルで確認しました。

## エビデンス
![image](https://user-images.githubusercontent.com/86661820/189095676-976961fe-7040-4cd3-8a96-444e5295421d.png)
![image](https://user-images.githubusercontent.com/86661820/189095745-5d9be63e-82d0-44f1-97ab-0bfff4c02f44.png)

