### PR TITLE
管理画面 Issue3 画面からイベント情報を変更出来るようにする #23

### DIFF
--- a/src/admin/edit.php
+++ b/src/admin/edit.php
@@ -21,14 +21,13 @@ $new_start_at = $new_start_at.":00";
 $new_end_at = str_replace(array("T"), " ", $new_end_at); //Tを空白へ変更
 $new_end_at = str_replace(array("-"), "/", $new_end_at); //Tを空白へ変更
 $new_end_at = $new_end_at.":00";
-$id =$_POST['event_id'];
-
+$event_id =$_POST['id_event'];
 
 if (isset($_POST['edit'])) {
   try {
     // $stmt = $db -> prepare('UPDATE events SET name = "waa", contents ="uoo" WHERE id = 1');
-    $stmt = $db->prepare('UPDATE events SET name = :name, contents = :contents, start_at = :start_at, end_at = :end_at WHERE id = :id');
-    $stmt->bindValue(':id', $id);
+    $stmt = $db->prepare('UPDATE events SET name = :name, contents = :contents, start_at = :start_at, end_at = :end_at WHERE id = :event_id');
+    $stmt->bindValue(':event_id', $event_id);
     $stmt->bindValue(':name', $new_name);
     $stmt->bindValue(':contents', $new_contents);
     $stmt->bindValue(':start_at', $new_start_at);

--- a/src/admin/edit.php
+++ b/src/admin/edit.php
@@ -1,0 +1,43 @@
+<?php
+require('../dbconnect.php');
+session_start();
+if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
+  // SESSIONにloginカラムが設定されていて、SESSIONに登録されている時間から1日以内なら
+  $_SESSION['time'] = time();
+  // SESSIONの時間を現在時刻に更新
+} else {
+  // そうじゃないならログイン画面に飛ぶ
+  header('Location: http://' . $_SERVER['HTTP_HOST'] . '/auth/login/index.php');
+  exit(); 
+}
+
+$new_name = $_POST['new_name'];
+$new_contents = nl2br($_POST['new_contents']);
+$new_start_at = $_POST['new_start_at'];
+$new_end_at = $_POST['new_finish_at'];
+$new_start_at = str_replace(array("T"), " ", $new_start_at); //Tを空白へ変更
+$new_start_at = str_replace(array("-"), "/", $new_start_at); //Tを空白へ変更
+$new_start_at = $new_start_at.":00";
+$new_end_at = str_replace(array("T"), " ", $new_end_at); //Tを空白へ変更
+$new_end_at = str_replace(array("-"), "/", $new_end_at); //Tを空白へ変更
+$new_end_at = $new_end_at.":00";
+$id =$_POST['event_id'];
+
+
+if (isset($_POST['edit'])) {
+  try {
+    // $stmt = $db -> prepare('UPDATE events SET name = "waa", contents ="uoo" WHERE id = 1');
+    $stmt = $db->prepare('UPDATE events SET name = :name, contents = :contents, start_at = :start_at, end_at = :end_at WHERE id = :id');
+    $stmt->bindValue(':id', $id);
+    $stmt->bindValue(':name', $new_name);
+    $stmt->bindValue(':contents', $new_contents);
+    $stmt->bindValue(':start_at', $new_start_at);
+    $stmt->bindValue(':end_at', $new_end_at);
+    $stmt->execute();
+    header('Location: http://' . $_SERVER['HTTP_HOST'] . '/admin/events_list.php');
+    exit();
+  } catch (PDOException $e) {
+    echo "エラーが発生しました";
+    exit();
+  }            
+}

--- a/src/admin/event_edit.php
+++ b/src/admin/event_edit.php
@@ -1,0 +1,69 @@
+<?php
+require('../dbconnect.php');
+session_start();
+if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
+  // SESSIONにloginカラムが設定されていて、SESSIONに登録されている時間から1日以内なら
+  $_SESSION['time'] = time();
+  // SESSIONの時間を現在時刻に更新
+} else {
+  // そうじゃないならログイン画面に飛ぶ
+  header('Location: http://' . $_SERVER['HTTP_HOST'] . '/auth/login/index.php');
+  exit();
+}
+echo $_POST['event_id'];
+
+?>
+
+<!DOCTYPE html>
+
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>Schedule | POSSE</title>
+</head>
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+      <!-- 
+      <div>
+        <a href="/auth/login" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ログイン</a>
+      </div>
+      -->
+    </div>
+  </header>
+
+  <main class="bg-gray-100">
+    <div class="w-full mx-auto p-5">
+      <div>
+        <!-- 管理画面から登録済みのイベント一覧が確認できること、 -->
+        <!-- また、イベントを選択してイベント名、開催日時、イベント内容を変更できること -->
+          <div class="flex justify-between items-center mb-3">
+            <h2 class="text-sm font-bold">イベント情報の編集</h2>
+          </div>
+          <form action="edit.php" method="POST" class="w-full p-4 text-sm mb-3">
+            <dd>イベント名</dd>
+            <dt><input name='new_name' type="text"></dt>
+            <dd>開始時間</dd>
+            <dt><input name='new_start_at' type="datetime-local"></dt>
+            <dd>終了時間</dd>
+            <dt><input name='new_finish_at' type="datetime-local"></dt>
+            <dd>イベント内容</dd>
+            <dt><textarea name="new_contents" id="contents" class="w-full p-4 text-sm mb-3"></textarea></dt>
+            <input type="hidden" value="<?php echo $_POST['event_id'];?> ">
+            <input type="submit" name="edit" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" style="display:hide" value ="情報を修正">
+          </form>
+          <a href='events_list.php'>イベント一覧に戻る</a>
+      </div>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/src/admin/event_edit.php
+++ b/src/admin/event_edit.php
@@ -10,7 +10,6 @@ if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
   header('Location: http://' . $_SERVER['HTTP_HOST'] . '/auth/login/index.php');
   exit();
 }
-echo $_POST['event_id'];
 
 ?>
 
@@ -57,7 +56,7 @@ echo $_POST['event_id'];
             <dt><input name='new_finish_at' type="datetime-local"></dt>
             <dd>イベント内容</dd>
             <dt><textarea name="new_contents" id="contents" class="w-full p-4 text-sm mb-3"></textarea></dt>
-            <input type="hidden" value="<?php echo $_POST['event_id'];?> ">
+            <input type="hidden" name = "id_event" value="<?php echo $_POST['event_id'];?> ">
             <input type="submit" name="edit" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300" style="display:hide" value ="情報を修正">
           </form>
           <a href='events_list.php'>イベント一覧に戻る</a>

--- a/src/admin/events_list.php
+++ b/src/admin/events_list.php
@@ -1,0 +1,63 @@
+<?php
+require('../dbconnect.php');
+session_start();
+if (isset($_SESSION['login']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
+  // SESSIONにloginカラムが設定されていて、SESSIONに登録されている時間から1日以内なら
+  $_SESSION['time'] = time();
+  // SESSIONの時間を現在時刻に更新
+} else {
+  // そうじゃないならログイン画面に飛ぶ
+  header('Location: http://' . $_SERVER['HTTP_HOST'] . '/auth/login/index.php');
+  exit();
+}
+
+$stmt = $db->prepare('SELECT * from events');
+$stmt->execute();
+$events = $stmt->fetchAll();
+
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>Schedule | POSSE</title>
+</head>
+
+<body?>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+      <!-- 
+      <div>
+        <a href="/auth/login" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ログイン</a>
+      </div>
+      -->
+    </div>
+  </header>
+
+  <main class="bg-gray-100">
+    <div class="w-full mx-auto p-5">
+      <div id="events-list">
+      <!-- 管理画面から登録済みのイベント一覧が確認できること、 -->
+      <!-- また、イベントを選択してイベント名、開催日時、イベント内容を変更できること -->
+          <div class="flex justify-between items-center mb-3">
+            <h2 class="text-sm font-bold">登録済みイベント一覧</h2>
+          </div>
+          <?php foreach ($events as $event) : ?>
+            <form action="event_edit.php" method="post">
+              <input type="submit" name="event_name" value="<?php echo $event['name']; ?>">
+              <input type="button" name="event_id" value="<?php echo $event['id']; ?>">
+            </form>
+            <?php endforeach; ?>
+        </div>
+  </main>
+</body>
+</html>

--- a/src/admin/events_list.php
+++ b/src/admin/events_list.php
@@ -54,7 +54,8 @@ $events = $stmt->fetchAll();
           <?php foreach ($events as $event) : ?>
             <form action="event_edit.php" method="post">
               <input type="submit" name="event_name" value="<?php echo $event['name']; ?>">
-              <input type="button" name="event_id" value="<?php echo $event['id']; ?>">
+              <input type="hidden" name="event_id" value="<?php echo $event['id']; ?>">
+              <input type="button" name="id" value="">
             </form>
             <?php endforeach; ?>
         </div>

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -125,6 +125,8 @@ $finish_date = $finish_date.":00";
 
   <main class="bg-gray-100  h-screen">
     <div class="w-full mx-auto py-10 px-5">
+      <a href="events_list.php">登録済みイベント一覧</a>
+
       <!-- 管理画面からユーザ登録出来る -->
       <h1 class="text-md font-bold mb-5">ユーザ登録</h1>
       <form action="index.php" method="POST" class="w-full p-4 text-sm mb-3">
@@ -153,6 +155,5 @@ $finish_date = $finish_date.":00";
     </div>
   </main>  
   
-  <script src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 関連イシュー
- #23

## 検証したこと
管理者の情報でログインし、管理者画面から登録済みのイベントの一覧のページに遷移できるか確認しました。
登録済みのイベント一覧のページからイベントを選択すると、登録した情報を修正する画面に遷移し、そこで記入したイベント名・開催日時・イベント内容がDBの方に反映されているか確認しました。また、登録済みイベント一覧のページからも変更されているか確認しました
## エビデンス
![image](https://user-images.githubusercontent.com/86661820/189149591-90cd855d-72f9-4f9f-aee5-3a830e028c3d.png)
![image](https://user-images.githubusercontent.com/86661820/189149649-8ee6b86a-3306-4b2a-8138-00fa44f6ea9b.png)
![image](https://user-images.githubusercontent.com/86661820/189149885-f3d83322-8694-49d8-bc8d-e0d2896c2e95.png)
![image](https://user-images.githubusercontent.com/86661820/189149965-b9379d0e-01bc-482e-9233-15ac19a14b78.png)
![image](https://user-images.githubusercontent.com/86661820/189150189-f08f62ad-9545-4d3f-b0a2-598e9d6ce764.png)


<!-- こちらに画面キャプチャを貼ってください -->
